### PR TITLE
feat: make signature and deploy plugin compatible with warp-contracts…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "warp-contracts-plugin-evaluation-progress",
     "warp-contracts-plugin-ethers"
   ],
-  "dependencies": {
-    "warp-contracts": "1.2.54"
-  },
   "devDependencies": {
     "@types/jest": "^28.1.6",
     "@types/node": "^18.0.6",
@@ -23,6 +20,7 @@
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",
     "ts-node": "^10.2.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "warp-contracts": "1.3.0"
   }
 }

--- a/warp-contracts-plugin-deploy/package.json
+++ b/warp-contracts-plugin-deploy/package.json
@@ -46,7 +46,7 @@
     "node-stdlib-browser": "^1.2.0"
   },
   "peerDependencies": {
-    "warp-contracts": "*"
+    "warp-contracts": "1.3.x"
   },
   "devDependencies": {
     "@types/jest": "*",

--- a/warp-contracts-plugin-deploy/src/deploy/impl/CreateContractImpl.ts
+++ b/warp-contracts-plugin-deploy/src/deploy/impl/CreateContractImpl.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 import { SourceImpl } from './SourceImpl';
-import { Buffer } from 'warp-isomorphic';
 import {
   ArWallet,
   BundlrNodeType,
@@ -13,13 +12,14 @@ import {
   FromSrcTxContractData,
   LoggerFactory,
   Signature,
-  Signer,
-  SmartWeaveTags,
+  BundlerSigner,
   SourceData,
   Transaction,
   Warp,
   WarpFetchWrapper,
-  WARP_GW_URL
+  WARP_GW_URL,
+  SMART_WEAVE_TAGS,
+  WARP_TAGS
 } from 'warp-contracts';
 import { createData } from 'arbundles';
 import { isSigner } from '../../deploy/utils';
@@ -93,21 +93,19 @@ export class CreateContractImpl implements CreateContract {
 
     const contractTags = {
       contract: [
-        { name: SmartWeaveTags.APP_NAME, value: 'SmartWeaveContract' },
-        { name: SmartWeaveTags.APP_VERSION, value: '0.3.0' },
-        { name: SmartWeaveTags.CONTRACT_SRC_TX_ID, value: srcTxId },
-        { name: SmartWeaveTags.SDK, value: 'Warp' },
-        { name: SmartWeaveTags.NONCE, value: Date.now().toString() }
+        { name: SMART_WEAVE_TAGS.APP_NAME, value: 'SmartWeaveContract' },
+        { name: SMART_WEAVE_TAGS.APP_VERSION, value: '0.3.0' },
+        { name: SMART_WEAVE_TAGS.CONTRACT_SRC_TX_ID, value: srcTxId },
+        { name: SMART_WEAVE_TAGS.SDK, value: 'Warp' },
+        { name: WARP_TAGS.NONCE, value: Date.now().toString() }
       ],
       contractData: [
-        { name: SmartWeaveTags.CONTENT_TYPE, value: data && data['Content-Type'] },
-        { name: SmartWeaveTags.INIT_STATE, value: initState }
+        { name: SMART_WEAVE_TAGS.CONTENT_TYPE, value: data && data['Content-Type'] },
+        { name: WARP_TAGS.INIT_STATE, value: initState }
       ],
-      contractNonData: [{ name: SmartWeaveTags.CONTENT_TYPE, value: 'application/json' }],
-      contractTestnet: [{ name: SmartWeaveTags.WARP_TESTNET, value: '1.0.0' }],
-      contractEvaluationManifest: [
-        { name: SmartWeaveTags.MANIFEST, value: JSON.stringify(contractData.evaluationManifest) }
-      ]
+      contractNonData: [{ name: SMART_WEAVE_TAGS.CONTENT_TYPE, value: 'application/json' }],
+      contractTestnet: [{ name: WARP_TAGS.WARP_TESTNET, value: '1.0.0' }],
+      contractEvaluationManifest: [{ name: WARP_TAGS.MANIFEST, value: JSON.stringify(contractData.evaluationManifest) }]
     };
 
     if (!effectiveUseBundler) {
@@ -177,7 +175,7 @@ export class CreateContractImpl implements CreateContract {
 
   async createSource(
     sourceData: SourceData,
-    wallet: ArWallet | CustomSignature | Signer,
+    wallet: ArWallet | CustomSignature | BundlerSigner,
     disableBundling: boolean = false
   ): Promise<Transaction | DataItem> {
     return this.source.createSource(sourceData, wallet, disableBundling);

--- a/warp-contracts-plugin-deploy/src/deploy/wasm/WasmHandler.ts
+++ b/warp-contracts-plugin-deploy/src/deploy/wasm/WasmHandler.ts
@@ -1,11 +1,11 @@
 /* eslint-disable */
 import metering from 'warp-wasm-metering';
 import fs, { PathOrFileDescriptor } from 'fs';
-import { matchMutClosureDtor, SmartWeaveTags } from 'warp-contracts';
+import { matchMutClosureDtor, WARP_TAGS } from 'warp-contracts';
 
 const wasmTypeMapping: Map<number, string> = new Map([
   // [1, 'assemblyscript'],
-  [2, 'rust'],
+  [2, 'rust']
   /*[3, 'go']
   [4, 'swift'],
     [5, 'c']*/
@@ -36,19 +36,19 @@ export class WasmHandler {
     const moduleImports = WebAssembly.Module.imports(wasmModule);
     let lang: number;
 
-      // @ts-ignore
-      const module: WebAssembly.Instance = await WebAssembly.instantiate(this.src, dummyImports(moduleImports));
-      // @ts-ignore
-      if (!module.instance.exports.lang) {
-        throw new Error(`No info about source type in wasm binary. Did you forget to export "lang" function?`);
-      }
-      // @ts-ignore
-      lang = module.instance.exports.lang();
-      // @ts-ignore
-      wasmVersion = module.instance.exports.version();
-      if (!wasmTypeMapping.has(lang)) {
-        throw new Error(`Unknown wasm source type ${lang}`);
-      }
+    // @ts-ignore
+    const module: WebAssembly.Instance = await WebAssembly.instantiate(this.src, dummyImports(moduleImports));
+    // @ts-ignore
+    if (!module.instance.exports.lang) {
+      throw new Error(`No info about source type in wasm binary. Did you forget to export "lang" function?`);
+    }
+    // @ts-ignore
+    lang = module.instance.exports.lang();
+    // @ts-ignore
+    wasmVersion = module.instance.exports.version();
+    if (!wasmTypeMapping.has(lang)) {
+      throw new Error(`Unknown wasm source type ${lang}`);
+    }
 
     const wasmLang = wasmTypeMapping.get(lang);
     if (this.wasmSrcCodeDir == null) {
@@ -70,9 +70,9 @@ export class WasmHandler {
 
     const wasmData = this.joinBuffers(data);
     const srcWasmTags = [
-      { name: SmartWeaveTags.WASM_LANG, value: wasmLang },
-      { name: SmartWeaveTags.WASM_LANG_VERSION, value: wasmVersion.toString() },
-      { name: SmartWeaveTags.WASM_META, value: JSON.stringify(metadata) }
+      { name: WARP_TAGS.WASM_LANG, value: wasmLang },
+      { name: WARP_TAGS.WASM_LANG_VERSION, value: wasmVersion.toString() },
+      { name: WARP_TAGS.WASM_META, value: JSON.stringify(metadata) }
     ];
     return { wasmData, srcWasmTags };
   }

--- a/warp-contracts-plugin-signature/package.json
+++ b/warp-contracts-plugin-signature/package.json
@@ -37,7 +37,7 @@
     "safe-stable-stringify": "^2.4.1"
   },
   "peerDependencies": {
-    "warp-contracts": "*"
+    "warp-contracts": "1.3.x"
   },
   "engines": {
     "node": ">=16.5"

--- a/warp-contracts-plugin-signature/src/server/common.ts
+++ b/warp-contracts-plugin-signature/src/server/common.ts
@@ -1,5 +1,5 @@
 import Transaction, { Tag } from 'arweave/node/lib/transaction';
-import { SmartWeaveTags, TagsParser } from 'warp-contracts';
+import { SMART_WEAVE_TAGS, TagsParser } from 'warp-contracts';
 import { stringify } from 'safe-stable-stringify';
 import { encodeTxId } from './utils';
 import { Interaction } from './evm/evmSignatureVerification';
@@ -22,7 +22,7 @@ export const prepareTransaction = (tx: Transaction, ownerAddress: string) => {
 
   const isContractOrSource = decodedTags.some(
     (tag: Tag) =>
-      tag.name === SmartWeaveTags.APP_NAME &&
+      tag.name === SMART_WEAVE_TAGS.APP_NAME &&
       (tag.value === 'SmartWeaveContract' || tag.value === 'SmartWeaveContractSource')
   );
 

--- a/warp-contracts-plugin-signature/src/web/common.ts
+++ b/warp-contracts-plugin-signature/src/web/common.ts
@@ -1,5 +1,5 @@
 import Transaction, { Tag } from 'arweave/web/lib/transaction';
-import { SmartWeaveTags, TagsParser } from 'warp-contracts/web';
+import { SMART_WEAVE_TAGS, TagsParser } from 'warp-contracts/web';
 import { stringify } from 'safe-stable-stringify';
 import { encodeTxId } from './utils';
 import { Interaction } from './evm/evmSignatureVerification';
@@ -22,7 +22,7 @@ export const prepareTransaction = (tx: Transaction, ownerAddress: string) => {
 
   const isContractOrSource = decodedTags.some(
     (tag: Tag) =>
-      tag.name === SmartWeaveTags.APP_NAME &&
+      tag.name === SMART_WEAVE_TAGS.APP_NAME &&
       (tag.value === 'SmartWeaveContract' || tag.value === 'SmartWeaveContractSource')
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,10 +2692,15 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.4.1, acorn@^8.7.0, acorn@^8.8.0:
+acorn@^8.4.1, acorn@^8.8.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+
+acorn@^8.7.0:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 adler-32@~1.3.0:
   version "1.3.1"
@@ -4094,9 +4099,9 @@ fast-base64-decode@^1.0.0:
   integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
 
 fast-copy@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.0.tgz#875ebf33b13948ae012b6e51d33da5e6e7571ab8"
-  integrity sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
+  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -4373,7 +4378,12 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+graceful-fs@^4.2.0:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -5864,9 +5874,9 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
     brace-expansion "^1.1.7"
 
 minimatch@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
-  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -5954,9 +5964,9 @@ node-fetch@^2.6.1:
     whatwg-url "^5.0.0"
 
 node-gyp-build@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
-  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
+  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -6276,7 +6286,20 @@ react-native-get-random-values@^1.4.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.3.3:
+readable-stream@^2.0.0, readable-stream@^2.0.5:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.3:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -6290,9 +6313,9 @@ readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.3.3:
     util-deprecate "~1.0.1"
 
 readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -6820,9 +6843,9 @@ unbox-primitive@^1.0.2:
     which-boxed-primitive "^1.0.2"
 
 undici@^5.8.0:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.13.0.tgz#56772fba89d8b25e39bddc8c26a438bd73ea69bb"
-  integrity sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==
+  version "5.21.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.21.0.tgz#b00dfc381f202565ab7f52023222ab862bb2494f"
+  integrity sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==
   dependencies:
     busboy "^1.6.0"
 
@@ -6840,9 +6863,9 @@ universal-cookie@^4.0.4:
     cookie "^0.4.0"
 
 unzipit@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/unzipit/-/unzipit-1.4.0.tgz#69fc6eef47730897e39b15e54f972d60a1a92441"
-  integrity sha512-hjoB8j1igXJgmxqaAvqkIW+faKTpG9cPK6QvkBhNCyd8OPWqODXTBVqTEmZbz62K5J/dX4Xa8lTa0NRikQwSjQ==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/unzipit/-/unzipit-1.4.2.tgz#f89b492aa61f8379d0a01fc04c9267b27b4a58ec"
+  integrity sha512-m7UOmLY0AxrvHs0f1x4FCjH5HJR57a891MaYxIMcfyLwrGWW8GBFjFvacQz/m/QgPvnmq2RVctlEmDKpZp7wfQ==
   dependencies:
     uzip-module "^1.0.2"
 
@@ -6937,10 +6960,10 @@ warp-contracts-pubsub@^1.0.3:
     "@aws-amplify/api" "^4.0.61"
     "@aws-amplify/core" "4.7.12"
 
-warp-contracts@1.2.54:
-  version "1.2.54"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.2.54.tgz#6f79cc5ff42c615a81d26114f5025e58711e5db3"
-  integrity sha512-L+axxbyJmk9JwILjddjKYVxJhofgRwXU2K8gDZxGotSA2632YkYVcXOZN7VOKgeXK+tzxEQniB4n4csnO+/GKA==
+warp-contracts@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.3.0.tgz#c00bab24a0d62f5f93748db6057aec71689c806b"
+  integrity sha512-CG7pPv4YXenf95HL89a3CR3qj0cOntZw1fpoYWlspZg5xUKow8nETpXqYjrBCK7F1DaHWHgXxMWEhHEwWfOK0A==
   dependencies:
     "@idena/vrf-js" "^1.0.1"
     archiver "^5.3.0"


### PR DESCRIPTION
After changes with warp-sdk@1.2.57 deploy plugin and verification stopped working. Because, we are using peer-dependencies, so from now one warp-sdk@1.2.57 requires newer version of signature and deploy plugin :) 